### PR TITLE
Add `register_docker`, `--force` and ENV vars for defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 RUN \
     # install packages dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,55 @@
 FROM ubuntu:18.04
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN \
     # install packages dependencies
     apt-get update -yqq \
     && apt-get install -yqq \
-        curl \
-        git \
-        locales \
-        wget \
-        squashfs-tools \
-        dh-autoreconf \
         build-essential \
+        cryptsetup \
+        curl \
+        dh-autoreconf \
+        git \
+        libarchive-dev \
+        libglib2.0-dev \
+        libseccomp-dev \
+        locales \
+        pkg-config \
         python-pip \
         python3-pip \
         python2.7 \
         python3.6 \
+        runc \
+        squashfs-tools \
         uuid-runtime \
-        libarchive-dev \
-    && apt-get clean \
-    \
+        wget \
+    && apt-get cleans
+
+RUN \
     # configure locale, see https://github.com/rocker-org/rocker/issues/19
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && locale-gen en_US.utf8 \
-    && /usr/sbin/update-locale LANG=en_US.UTF-8 \
-    \
+    && /usr/sbin/update-locale LANG=en_US.UTF-8
+
+RUN \
+    # Install Go
+    export VERSION=1.19.5 OS=linux ARCH=amd64 \
+    && wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz \
+        https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz \
+    && tar -C /usr/local -xzf /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz && \
+    && echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc \
+    && source ~/.bashrc
+
+RUN \
     # Install singularity
+    SINGULARITY_VERSION=v3.10.5 \
     && SOURCE=/tmp/singularity_source \
-    && git clone https://github.com/singularityware/singularity.git $SOURCE \
+    && git clone --recurse-submodules https://github.com/sylabs/singularity.git $SOURCE \
     && cd $SOURCE \
-    && git checkout tags/2.6.1 \
-    && ./autogen.sh \
-    && ./configure \
-    && make install \
+    && git checkout --recurse-submodules ${SINGULARITY_VERSION} \
+    && ./mconfig \
+    && make -C builddir \
+    && sudo make -C builddir install \
     && rm -rf $SOURCE
 
 # set locales

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 This package is available at [PyPi][pypi_base]:
 
     pip install register_apps
+    # or with the latest version
+    pip install git+https://github.com/papaemmelab/register_apps.git#egg=register_apps
 
 ## Usage
 
@@ -113,6 +115,16 @@ This package it's used to register versionized and containerized applications wi
         #!/bin/bash
         /path/to/.virtualenvs/production__click_annotvcf__v1.0.7/bin/click_annotvcf "$@"
 
+### Environment Variables
+
+Some default values can be set using environment variables:
+
+| Variable | Default value for | Description | Example |
+| --- | --- | --- | --- |
+| `REGISTER_APPS_BINDIR` | `--bindir` | Path to the directory where the executables symlinks will be created | i.e. `/apps/local/bin` |
+| `REGISTER_APPS_OPTDIR` | `--optdir` | Path to the directory where the containers and scripts will be installed | i.e. `/apps/opt` |
+| `REGISTER_APPS_TMPVAR` or `TMP_DIR` | `--tmpvar` | Path to the temporary directory | i.e. `/tmp` |
+| `REGISTER_APPS_VOLUMES` | `--volumes` | Comma-separated volumes in the format `{src}:{dst}` or just `{src}` | i.e. `/mnt/data,/scratch,/usr/local/data:/data` will mount in docker as `-v /mnt/data:/mnt/data -v /scratch:/scratch -v /usr/local/data:/data`.|
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![docker badge][automated_badge]][docker_base]
 [![code formatting][black_badge]][black_base]
 
-👾 Register versioned [toil container] pipelines, singularity containers, and python packages.
+👾 Register versioned [toil container] pipelines, [singularity] containers, and python packages.
 
 ## Installation
 
@@ -123,7 +123,6 @@ Some default values can be set using environment variables:
 | --- | --- | --- | --- |
 | `REGISTER_APPS_BIN` | `--bindir` | Path to the directory where the executables symlinks will be created | i.e. `/apps/local/bin` |
 | `REGISTER_APPS_OPT` | `--optdir` | Path to the directory where the containers and scripts will be installed | i.e. `/apps/opt` |
-| `REGISTER_APPS_TMPVAR` or `TMP_DIR` | `--tmpvar` | Path to the temporary directory | i.e. `/tmp` |
 | `REGISTER_APPS_VOLUMES` | `--volumes` | Comma-separated volumes in the format `{src}:{dst}` or just `{src}` | i.e. `/mnt/data,/scratch,/usr/local/data:/data` will mount in docker as `-v /mnt/data:/mnt/data -v /scratch:/scratch -v /usr/local/data:/data`.|
 
 ## Contributing
@@ -138,7 +137,6 @@ This package was created using [Cookiecutter] and the
 [virtual environments]: http://virtualenvwrapper.readthedocs.io/en/latest/
 [toil container]: https://github.com/papaemmelab/toil_container
 [singularity]: http://singularity.lbl.gov/
-[docker2singularity]: https://github.com/singularityware/docker2singularity
 [cookiecutter]: https://github.com/audreyr/cookiecutter
 [papaemmelab/cookiecutter-toil]: https://github.com/papaemmelab/cookiecutter-toil
 [`--batchSystem`]: http://toil.readthedocs.io/en/latest/developingWorkflows/batchSystem.html?highlight=BatchSystem

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ Some default values can be set using environment variables:
 
 | Variable | Default value for | Description | Example |
 | --- | --- | --- | --- |
-| `REGISTER_APPS_BINDIR` | `--bindir` | Path to the directory where the executables symlinks will be created | i.e. `/apps/local/bin` |
-| `REGISTER_APPS_OPTDIR` | `--optdir` | Path to the directory where the containers and scripts will be installed | i.e. `/apps/opt` |
+| `REGISTER_APPS_BIN` | `--bindir` | Path to the directory where the executables symlinks will be created | i.e. `/apps/local/bin` |
+| `REGISTER_APPS_OPT` | `--optdir` | Path to the directory where the containers and scripts will be installed | i.e. `/apps/opt` |
 | `REGISTER_APPS_TMPVAR` or `TMP_DIR` | `--tmpvar` | Path to the temporary directory | i.e. `/tmp` |
 | `REGISTER_APPS_VOLUMES` | `--volumes` | Comma-separated volumes in the format `{src}:{dst}` or just `{src}` | i.e. `/mnt/data,/scratch,/usr/local/data:/data` will mount in docker as `-v /mnt/data:/mnt/data -v /scratch:/scratch -v /usr/local/data:/data`.|
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ This package was created using [Cookiecutter] and the
 [singularity]: http://singularity.lbl.gov/
 [cookiecutter]: https://github.com/audreyr/cookiecutter
 [papaemmelab/cookiecutter-toil]: https://github.com/papaemmelab/cookiecutter-toil
-[`--batchSystem`]: http://toil.readthedocs.io/en/latest/developingWorkflows/batchSystem.html?highlight=BatchSystem
 [docker_base]: https://hub.docker.com/r/papaemmelab/register_apps
 [docker_badge]: https://img.shields.io/docker/cloud/build/papaemmelab/register_apps.svg
 [automated_badge]: https://img.shields.io/docker/cloud/automated/papaemmelab/register_apps.svg
@@ -147,7 +146,7 @@ This package was created using [Cookiecutter] and the
 [codecov_base]: https://codecov.io/gh/papaemmelab/register_apps
 [pypi_badge]: https://img.shields.io/pypi/v/register_apps.svg
 [pypi_base]: https://pypi.org/pypi/register_apps
-[travis_badge]: https://img.shields.io/travis/papaemmelab/register_apps.svg
-[travis_base]: https://travis-ci.org/papaemmelab/register_apps
+[travis_badge]: https://app.travis-ci.com/papaemmelab/register_apps.svg?token=P6GGbmdLPwysz69FFv2X&branch=master
+[travis_base]: https://app.travis-ci.com/papaemmelab/register_apps
 [black_badge]: https://img.shields.io/badge/code%20style-black-000000.svg
 [black_base]: https://github.com/ambv/black

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -168,6 +168,7 @@ def register_image(  # pylint: disable=R0913
             "--workdir",
             workdir,
             " ".join(f"--volume {i}:{j}" for i, j in volumes),
+            "--entrypoint ''" if command == "bash" else "",
             image_url,
             command,
             '"$@"\n',

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -318,13 +318,9 @@ def register_python(pypi_name, pypi_version, github_user, bindir, optdir, python
         fg="green",
     )
 
-
 def _get_or_create_image(optdir, singularity, image_url):
     """Pull image if it's not locally available and store it."""
-    singularity_images = []
-    for i in ["*.sif", "*.simg"]:
-        singularity_images += list(optdir.glob(i))
-
+    singularity_images = list(optdir.glob("*.sif")) + list(optdir.glob("*.simg"))
     if len(singularity_images) > 1:
         click.echo(f"Found multiple images at {optdir}. Using {singularity_images[0]}.")
 
@@ -335,8 +331,8 @@ def _get_or_create_image(optdir, singularity, image_url):
             ["/bin/bash", "-c", f"umask 22 && {singularity} pull {image_url}"],
             cwd=optdir,
         )
-        singularity_images = glob(join(optdir, "*.sif")) + glob(join(optdir, "*.simg"))
-        assert len(singularity_images) < 1, f"Image not found: {optdir}"
+        singularity_images = list(optdir.glob("*.sif")) + list(optdir.glob("*.simg"))
+        assert singularity_images, f"Image not found: {optdir}"
 
     singularity_image = singularity_images[0]
     # fix singularity permissions

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -182,6 +182,7 @@ def register_image(  # pylint: disable=R0913
         fg="green",
     )
 
+
 @click.command()
 @options.TARGET
 @options.COMMAND
@@ -198,6 +199,7 @@ def register_image(  # pylint: disable=R0913
 def register_singularity(singularity, *args, **kwargs):
     """Register versioned singularity command in a bin directory."""
     register_image(image_type="singularity", runtime=singularity, *args, **kwargs)
+
 
 @click.command()
 @options.TARGET

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -37,6 +37,8 @@ from register_apps import utils
 @options.TMPVAR
 @options.VOLUMES
 @options.SINGULARITY
+@options.VIRTUALENVWRAPPER
+@options.CONTAINER
 def register_toil(
     pypi_name,
     pypi_version,
@@ -49,9 +51,11 @@ def register_toil(
     image_user,
     github_user,
     singularity,
+    virtualenvwrapper,
+    container,
 ):
     """Register versioned toil container pipelines in a bin directory."""
-    virtualenvwrapper = shutil.which("virtualenvwrapper.sh")
+    virtualenvwrapper = shutil.which(virtualenvwrapper)
     python = shutil.which(python)
     optdir = Path(optdir) / pypi_name / pypi_version
     bindir = Path(bindir)
@@ -98,8 +102,20 @@ def register_toil(
     command = [
         toolpath,
         '"$@"',
-        "--singularity",
-        _get_or_create_image(optdir, singularity, image_url),
+    ]
+
+    if container == "singularity":
+        command += [
+            "--singularity",
+            _get_or_create_image(optdir, singularity, image_url),
+        ]
+    else: # container == "docker"
+        command += [
+            "--docker",
+            image_url,
+        ]
+
+    command += [
         " ".join(f"--volumes {i} {j}" for i, j in volumes),
         "--workDir",
         tmpvar,

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -302,13 +302,14 @@ def _get_or_create_image(optdir, singularity, image_url):
 
     if singularity_images:
         click.echo(f"Image exists at: {singularity_images[0]}")
+        singularity_image = singularity_images[0]
     else:
         subprocess.check_call(
             ["/bin/bash", "-c", f"umask 22 && {singularity} pull {image_url}"],
             cwd=optdir,
         )
+        singularity_image = next(optdir.glob("*.sif"), next(optdir.glob("*.simg")))
 
     # fix singularity permissions
-    singularity_image = next(optdir.glob("*.simg"), next(optdir.glob("*.sif")))
     singularity_image.chmod(mode=0o755)
     return str(singularity_image)

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -294,12 +294,11 @@ def register_python(pypi_name, pypi_version, github_user, bindir, optdir, python
 def _get_or_create_image(optdir, singularity, image_url):
     """Pull image if it's not locally available and store it."""
     singularity_images = []
-    for i in ["*.simg", "*.sif"]:
+    for i in ["*.sif", "*.simg"]:
         singularity_images += list(optdir.glob(i))
 
-    assert (
-        not singularity_images or len(singularity_images) == 1
-    ), f"Found multiple images at {optdir}"
+    if len(singularity_images) > 1:
+        click.echo(f"Found multiple images at {optdir}. Using {singularity_images[0]}.")
 
     if singularity_images:
         click.echo(f"Image exists at: {singularity_images[0]}")

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -168,7 +168,7 @@ def register_image(  # pylint: disable=R0913
             "--workdir",
             workdir,
             " ".join(f"--volume {i}:{j}" for i, j in volumes),
-            "--entrypoint ''" if command == "bash" else "",
+            "--entrypoint ''" if command else "",
             image_url,
             command,
             '"$@"\n',

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -64,9 +64,11 @@ def register_toil(
     optexe = optdir / pypi_name
     binexe = bindir / f"{pypi_name}_{pypi_version}"
     
-    if image_url and container == "singularity":
+    image_url = image_url or f"{image_user}/{pypi_name}:{pypi_version}"
+    if container == "singularity" and not image_url.startswith("docker://"):
         image_url = f"docker://{image_url}"
-    image_url = image_url or f"docker://{image_user}/{pypi_name}:{pypi_version}"
+    if container == "docker" and image_url.startswith("docker://"):
+        image_url = image_url.replace("docker://", "")
 
     # check paths
     assert python, "Could not determine the python path."

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -38,7 +38,6 @@ from register_apps import utils
 @options.TMPVAR
 @options.VOLUMES
 @options.SINGULARITY
-@options.FORCE
 def register_toil(
     pypi_name,
     pypi_version,

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -63,6 +63,9 @@ def register_toil(
     binexe = bindir / f"{pypi_name}_{pypi_version}"
     image_url = image_url or f"docker://{image_user}/{pypi_name}:{pypi_version}"
 
+    if container == "singularity":
+        image_url = f"docker://{image_url}"
+
     # check paths
     assert python, "Could not determine the python path."
     assert virtualenvwrapper, "Could not determine the virtualenvwrapper.sh path."
@@ -147,6 +150,8 @@ def register_image(  # pylint: disable=R0913
     tmpvar,
     volumes,
 ):
+    if image_type == "singularity":
+        image_url = f"docker://{image_url}"
     optdir = Path(optdir) / image_repository / image_version
     bindir = Path(bindir)
     optexe = optdir / target

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -25,8 +25,15 @@ import click
 from register_apps import options
 from register_apps import utils
 
+EPILOG_MSG = """
+Set env vars to set defaults: 
+  - REGISTER_APPS_BIN for --bindir
+  - REGISTER_APPS_OPT for --optdir
+  - REGISTER_APPS_VOLUMES for --volumes
+  - REGISTER_APPS_TMPVAR for --tmpvar
+"""
 
-@click.command()
+@click.command(epilog=EPILOG_MSG)
 @options.PYPI_NAME
 @options.PYPI_VERSION
 @options.IMAGE_USER
@@ -118,7 +125,7 @@ def register_toil(
     )
 
 
-@click.command()
+@click.command(epilog=EPILOG_MSG)
 @options.TARGET
 @options.COMMAND
 @options.IMAGE_REPOSITORY
@@ -182,7 +189,7 @@ def register_singularity(  # pylint: disable=R0913
     )
 
 
-@click.command()
+@click.command(epilog=EPILOG_MSG)
 @options.PYPI_NAME
 @options.PYPI_VERSION
 @options.GITHUB_USER

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -158,8 +158,10 @@ def register_image(  # pylint: disable=R0913
     workdir = f"{tmpvar}/${{USER}}_{image_repository}_{image_version}_`uuidgen`"
     
     image_url = image_url or f"{image_user}/{image_repository}:{image_version}"
-    if image_type == "singularity":
+    if image_type == "singularity" and not image_url.startswith("docker://"):
         image_url = f"docker://{image_url}"
+    if image_type == "docker" and image_url.startswith("docker://"):
+        image_url = image_url.replace("docker://", "")
 
     # do not overwrite targets
     if not force and (os.path.isfile(optexe) or os.path.isfile(binexe)):  # pragma: no cover

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -25,15 +25,7 @@ import click
 from register_apps import options
 from register_apps import utils
 
-EPILOG_MSG = """
-Set env vars to set defaults: 
-  - REGISTER_APPS_BIN for --bindir
-  - REGISTER_APPS_OPT for --optdir
-  - REGISTER_APPS_VOLUMES for --volumes
-  - REGISTER_APPS_TMPVAR for --tmpvar
-"""
-
-@click.command(epilog=EPILOG_MSG)
+@click.command()
 @options.PYPI_NAME
 @options.PYPI_VERSION
 @options.IMAGE_USER
@@ -125,7 +117,7 @@ def register_toil(
     )
 
 
-@click.command(epilog=EPILOG_MSG)
+@click.command()
 @options.TARGET
 @options.COMMAND
 @options.IMAGE_REPOSITORY
@@ -189,7 +181,7 @@ def register_singularity(  # pylint: disable=R0913
     )
 
 
-@click.command(epilog=EPILOG_MSG)
+@click.command()
 @options.PYPI_NAME
 @options.PYPI_VERSION
 @options.GITHUB_USER

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -61,10 +61,10 @@ def register_toil(
     bindir = Path(bindir)
     optexe = optdir / pypi_name
     binexe = bindir / f"{pypi_name}_{pypi_version}"
-    image_url = image_url or f"docker://{image_user}/{pypi_name}:{pypi_version}"
-
-    if container == "singularity":
+    
+    if container == "singularity" and image_url:
         image_url = f"docker://{image_url}"
+    image_url = image_url or f"docker://{image_user}/{pypi_name}:{pypi_version}"
 
     # check paths
     assert python, "Could not determine the python path."

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -318,8 +318,9 @@ def register_python(pypi_name, pypi_version, github_user, bindir, optdir, python
 
 def get_singularity_image_with_timeout(optdir):
     """Try to get the singularity image file from the optdir."""
-    timeout = 60  # timeout after 60 seconds
+    timeout = 10  # timeout after 60 seconds
     start_time = time.time()
+    click.echo(f"Looking for newly created Singularity image in {optdir}")
     while True:
         try:
             singularity_image = next(optdir.glob("*.sif"), next(optdir.glob("*.simg")))
@@ -345,10 +346,11 @@ def _get_or_create_image(optdir, singularity, image_url):
         click.echo(f"Image exists at: {singularity_images[0]}")
         singularity_image = singularity_images[0]
     else:
-        subprocess.check_call(
+        process = subprocess.Popen(
             ["/bin/bash", "-c", f"umask 22 && {singularity} pull {image_url}"],
             cwd=optdir,
         )
+        process.communicate()
         singularity_image = get_singularity_image_with_timeout(optdir)
 
     # fix singularity permissions

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -119,6 +119,7 @@ def register_toil(
 def register_image(  # pylint: disable=R0913
     bindir,
     command,
+    force,
     image_repository,
     image_type,
     image_url,
@@ -139,7 +140,7 @@ def register_image(  # pylint: disable=R0913
     workdir = f"{tmpvar}/${{USER}}_{image_repository}_{image_version}_`uuidgen`"
 
     # do not overwrite targets
-    if os.path.isfile(optexe) or os.path.isfile(binexe):  # pragma: no cover
+    if not force and (os.path.isfile(optexe) or os.path.isfile(binexe)):  # pragma: no cover
         raise click.UsageError(f"Targets exist, exiting...\n\t{optexe}\n\t{binexe}")
 
     # make sure dirs exist
@@ -195,6 +196,7 @@ def register_image(  # pylint: disable=R0913
 @options.TMPVAR
 @options.VOLUMES
 @options.SINGULARITY
+@options.FORCE
 @options.VERSION
 def register_singularity(singularity, *args, **kwargs):
     """Register versioned singularity command in a bin directory."""
@@ -213,6 +215,7 @@ def register_singularity(singularity, *args, **kwargs):
 @options.TMPVAR
 @options.VOLUMES
 @options.DOCKER
+@options.FORCE
 @options.VERSION
 def register_docker(docker, *args, **kwargs):
     """Register versioned docker command in a bin directory."""

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -38,7 +38,7 @@ from register_apps import utils
 @options.TMPVAR
 @options.VOLUMES
 @options.SINGULARITY
-@options.VERSION
+@options.FORCE
 def register_toil(
     pypi_name,
     pypi_version,

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -328,14 +328,15 @@ def _get_or_create_image(optdir, singularity, image_url):
 
     if singularity_images:
         click.echo(f"Image exists at: {singularity_images[0]}")
-        singularity_image = singularity_images[0]
     else:
-        process = subprocess.Popen(
+        subprocess.check_call(
             ["/bin/bash", "-c", f"umask 22 && {singularity} pull {image_url}"],
             cwd=optdir,
         )
-        singularity_image = glob(join(optdir, "*.simg")) + glob(join(optdir, "*.sif"))
+        singularity_images = glob(join(optdir, "*.sif")) + glob(join(optdir, "*.simg"))
+        assert len(singularity_images) < 1, f"Image not found: {optdir}"
 
+    singularity_image = singularity_images[0]
     # fix singularity permissions
     singularity_image.chmod(mode=0o755)
     return str(singularity_image)

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -233,9 +233,10 @@ def register_docker(docker, *args, **kwargs):
 @options.OPTDIR
 @options.PYTHON3
 @options.VERSION
-def register_python(pypi_name, pypi_version, github_user, bindir, optdir, python):
+@options.VIRTUALENVWRAPPER
+def register_python(pypi_name, pypi_version, github_user, bindir, optdir, python, virtualenvwrapper):
     """Register versioned python pipelines in a bin directory."""
-    virtualenvwrapper = shutil.which("virtualenvwrapper.sh")
+    virtualenvwrapper = shutil.which(virtualenvwrapper)
     python = shutil.which(python)
     optdir = Path(optdir) / pypi_name / pypi_version
     bindir = Path(bindir)

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -165,6 +165,8 @@ def register_image(  # pylint: disable=R0913
             "run",
             "-it",
             "--rm",
+            "-u",
+            "$(id -u):$(id -g)",
             "--workdir",
             workdir,
             " ".join(f"--volume {i}:{j}" for i, j in volumes),

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -318,9 +318,8 @@ def register_python(pypi_name, pypi_version, github_user, bindir, optdir, python
 
 def get_singularity_image_with_timeout(optdir):
     """Try to get the singularity image file from the optdir."""
-    timeout = 10  # timeout after 60 seconds
+    timeout = 60  # timeout after 60 seconds
     start_time = time.time()
-
     while True:
         try:
             singularity_image = next(optdir.glob("*.sif"), next(optdir.glob("*.simg")))
@@ -330,7 +329,6 @@ def get_singularity_image_with_timeout(optdir):
                 raise Exception(f"Timeout while waiting for Singularity image file in {optdir}")
             else:
                 time.sleep(1)  # wait for 1 second before trying again
-
     return singularity_image
 
 

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -136,7 +136,7 @@ def register_image(  # pylint: disable=R0913
     binexe = bindir / target
     image_source  = "docker://" if image_type == "singularity" else ""
     image_url = image_url or f"{image_source}{image_user}/{image_repository}:{image_version}"
-    workdir = f"{tmpvar}/${{USER}}_{image_repository}_{image_version}_`uuidgen`",
+    workdir = f"{tmpvar}/${{USER}}_{image_repository}_{image_version}_`uuidgen`"
 
     # do not overwrite targets
     if os.path.isfile(optexe) or os.path.isfile(binexe):  # pragma: no cover
@@ -162,7 +162,7 @@ def register_image(  # pylint: disable=R0913
         command = [
             runtime,
             "run",
-            "-it"
+            "-it",
             "--rm",
             "--workdir",
             workdir,

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -41,6 +41,7 @@ from register_apps import utils
 @options.SINGULARITY
 @options.VIRTUALENVWRAPPER
 @options.CONTAINER
+@options.ENVIRONMENT
 def register_toil(
     pypi_name,
     pypi_version,
@@ -55,6 +56,7 @@ def register_toil(
     singularity,
     virtualenvwrapper,
     container,
+    environment,
 ):
     """Register versioned toil container pipelines in a bin directory."""
     virtualenvwrapper = shutil.which(virtualenvwrapper)
@@ -80,7 +82,7 @@ def register_toil(
     bindir.mkdir(exist_ok=True, parents=True)
 
     # create virtual environment and install package
-    env = f"production__{pypi_name}__{pypi_version}"
+    env = f"{environment}__{pypi_name}__{pypi_version}"
     click.echo(f"Creating virtual environment '{env}'...")
     subprocess.check_output(
         [
@@ -149,6 +151,7 @@ def register_image(  # pylint: disable=R0913
     image_url,
     image_user,
     image_version,
+    no_home,
     optdir,
     runtime,
     target,
@@ -183,6 +186,7 @@ def register_image(  # pylint: disable=R0913
             "--workdir",
             workdir,
             " ".join(f"--bind {i}:{j}" for i, j in volumes),
+            "--no-home" if no_home else "",
             _get_or_create_image(optdir, runtime, image_url),
             command,
             '"$@"\n',
@@ -206,7 +210,8 @@ def register_image(  # pylint: disable=R0913
 
     # link executables
     click.echo("Creating and linking executable...")
-    optexe.write_text(f"#!/bin/bash\n{' '.join(command)}")
+    command = ' '.join(list(filter(None, command)))
+    optexe.write_text(f"#!/bin/bash\n{command}")
     optexe.chmod(mode=0o755)
     utils.force_symlink(optexe, binexe)
     click.secho(
@@ -229,6 +234,7 @@ def register_image(  # pylint: disable=R0913
 @options.SINGULARITY
 @options.FORCE
 @options.VERSION
+@options.NO_HOME
 def register_singularity(singularity, *args, **kwargs):
     """Register versioned singularity command in a bin directory."""
     register_image(image_type="singularity", runtime=singularity, *args, **kwargs)
@@ -250,7 +256,7 @@ def register_singularity(singularity, *args, **kwargs):
 @options.VERSION
 def register_docker(docker, *args, **kwargs):
     """Register versioned docker command in a bin directory."""
-    register_image(image_type="docker", runtime=docker, *args, **kwargs)
+    register_image(image_type="docker", runtime=docker, no_home=False, *args, **kwargs)
 
 
 @click.command()
@@ -262,7 +268,8 @@ def register_docker(docker, *args, **kwargs):
 @options.PYTHON3
 @options.VERSION
 @options.VIRTUALENVWRAPPER
-def register_python(pypi_name, pypi_version, github_user, bindir, optdir, python, virtualenvwrapper):
+@options.ENVIRONMENT
+def register_python(pypi_name, pypi_version, github_user, bindir, optdir, python, virtualenvwrapper, environment):
     """Register versioned python pipelines in a bin directory."""
     virtualenvwrapper = shutil.which(virtualenvwrapper)
     python = shutil.which(python)
@@ -280,7 +287,7 @@ def register_python(pypi_name, pypi_version, github_user, bindir, optdir, python
     bindir.mkdir(exist_ok=True, parents=True)
 
     # create virtual environment and install package
-    env = f"production__{pypi_name}__{pypi_version}"
+    env = f"{environment}__{pypi_name}__{pypi_version}"
     click.echo(f"Creating virtual environment '{env}'...")
     subprocess.check_output(
         [

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -63,6 +63,7 @@ def register_toil(
     bindir = Path(bindir)
     optexe = optdir / pypi_name
     binexe = bindir / f"{pypi_name}_{pypi_version}"
+    workdir = f"{tmpvar}/{pypi_name}_{pypi_version}_`uuidgen`"
     
     image_url = image_url or f"{image_user}/{pypi_name}:{pypi_version}"
     if container == "singularity" and not image_url.startswith("docker://"):
@@ -125,7 +126,7 @@ def register_toil(
     command += [
         " ".join(f"--volumes {i} {j}" for i, j in volumes),
         "--workDir",
-        tmpvar,
+        workdir,
         "\n",
     ]
 

--- a/register_apps/cli.py
+++ b/register_apps/cli.py
@@ -263,20 +263,21 @@ def register_docker(docker, *args, **kwargs):
 @options.PYPI_NAME
 @options.PYPI_VERSION
 @options.GITHUB_USER
+@options.COMMAND
 @options.BINDIR
 @options.OPTDIR
 @options.PYTHON3
 @options.VERSION
 @options.VIRTUALENVWRAPPER
 @options.ENVIRONMENT
-def register_python(pypi_name, pypi_version, github_user, bindir, optdir, python, virtualenvwrapper, environment):
+def register_python(pypi_name, pypi_version, github_user, command, bindir, optdir, python, virtualenvwrapper, environment):
     """Register versioned python pipelines in a bin directory."""
     virtualenvwrapper = shutil.which(virtualenvwrapper)
     python = shutil.which(python)
     optdir = Path(optdir) / pypi_name / pypi_version
     bindir = Path(bindir)
     optexe = optdir / pypi_name
-    binexe = bindir / f"{pypi_name}_{pypi_version}"
+    binexe = bindir / command or f"{pypi_name}_{pypi_version}"
 
     # check paths
     assert python, "Could not determine the python path."
@@ -301,12 +302,12 @@ def register_python(pypi_name, pypi_version, github_user, bindir, optdir, python
         install_cmd = (
             f"source {virtualenvwrapper} && workon {env} && "
             f"pip install git+https://github.com/{github_user}/"
-            f"{pypi_name}@{pypi_version}#egg={pypi_name} && which {pypi_name}"
+            f"{pypi_name}@{pypi_version}#egg={pypi_name} && which {command or pypi_name}"
         )
     else:
         install_cmd = (
             f"source {virtualenvwrapper} && workon {env} && "
-            f"pip install {pypi_name}=={pypi_version} && which {pypi_name}"
+            f"pip install {pypi_name}=={pypi_version} && which {command or pypi_name}"
         )
 
     click.echo(f"Installing package with '{install_cmd}'...")
@@ -314,11 +315,11 @@ def register_python(pypi_name, pypi_version, github_user, bindir, optdir, python
     toolpath = toolpath.decode("utf-8").strip().split("\n")[-1]
 
     # build command
-    command = [toolpath, '"$@"', "\n"]
+    cmd = [toolpath, '"$@"', "\n"]
 
     # link executables
     click.echo("Creating and linking executable...")
-    optexe.write_text(f"#!/bin/bash\n{' '.join(command)}")
+    optexe.write_text(f"#!/bin/bash\n{' '.join(cmd)}")
     optexe.chmod(mode=0o755)
     utils.force_symlink(optexe, binexe)
     click.secho(

--- a/register_apps/options.py
+++ b/register_apps/options.py
@@ -56,7 +56,7 @@ TMPVAR = click.option(
     "--tmpvar",
     show_default=True,
     help="environment variable used for workdir: --workDir ${tmpvar}. Use $REGISTER_APPS_TMPVAR or $TMP_DIR/$TMPDIR/$TMP.",
-    default=os.getenv("REGISTER_APPS_TMPVAR") or os.getenv("TMP_DIR") or os.getenv("TMPDIR") or os.getenv("TMP") or "/tmp",
+    default="$TMP_DIR",
 )
 BINDIR = click.option(
     "--bindir",

--- a/register_apps/options.py
+++ b/register_apps/options.py
@@ -47,26 +47,26 @@ VOLUMES = click.option(
     multiple=True,
     default=_DEFAULT_VOLUMES,
     show_default=False,
-    help=f"volumes tuples to be passed to singularity [default={_DEFAULT_VOLUMES}]",
+    help=f"volumes tuples to be passed to singularity. Use \$REGISTER_APPS_VOLUMES [default={_DEFAULT_VOLUMES}]",
 )
 TMPVAR = click.option(
     "--tmpvar",
     show_default=True,
-    help="environment variable used for workdir: --workDir ${tmpvar}",
+    help="environment variable used for workdir: --workDir ${tmpvar}. Use \$REGISTER_APPS_TMPVAR",
     default=os.getenv("REGISTER_APPS_TMPVAR", "TMP_DIR"),
 )
 BINDIR = click.option(
     "--bindir",
     show_default=True,
     type=click.Path(resolve_path=True, dir_okay=True),
-    help="path were executables will be linked to",
+    help="path were executables will be linked to. Use \$REGISTER_APPS_BIN",
     default=os.getenv("REGISTER_APPS_BIN", _DEFAULT_BINDIR),
 )
 OPTDIR = click.option(
     "--optdir",
     show_default=True,
     type=click.Path(resolve_path=True, dir_okay=True),
-    help="path were images will be versioned and cached",
+    help="path were images will be versioned and cached. Use \$REGISTER_APPS_OPT",
     default=os.getenv("REGISTER_APPS_OPT", _DEFAULT_OPTDIR),
 )
 PYTHON2 = click.option(

--- a/register_apps/options.py
+++ b/register_apps/options.py
@@ -53,21 +53,21 @@ TMPVAR = click.option(
     "--tmpvar",
     show_default=True,
     help="environment variable used for workdir: --workDir ${tmpvar}",
-    default=os.getenv("REGISTER_APP_TMPVAR", "TMP_DIR"),
+    default=os.getenv("REGISTER_APPS_TMPVAR", "TMP_DIR"),
 )
 BINDIR = click.option(
     "--bindir",
     show_default=True,
     type=click.Path(resolve_path=True, dir_okay=True),
     help="path were executables will be linked to",
-    default=os.getenv("REGISTER_APP_BIN", _DEFAULT_BINDIR),
+    default=os.getenv("REGISTER_APPS_BIN", _DEFAULT_BINDIR),
 )
 OPTDIR = click.option(
     "--optdir",
     show_default=True,
     type=click.Path(resolve_path=True, dir_okay=True),
     help="path were images will be versioned and cached",
-    default=os.getenv("REGISTER_APP_OPT", _DEFAULT_OPTDIR),
+    default=os.getenv("REGISTER_APPS_OPT", _DEFAULT_OPTDIR),
 )
 PYTHON2 = click.option(
     "--python",

--- a/register_apps/options.py
+++ b/register_apps/options.py
@@ -7,10 +7,10 @@ from register_apps import __version__
 _DEFAULT_OPTDIR = "/work/isabl/local"
 _DEFAULT_BINDIR = "/work/isabl/bin"
 _DEFAULT_VOLUMES = (
-    ("/ifs", "/ifs"),
     ("/juno", "/juno"),
     ("/work", "/work"),
-    ("/res", "/res"),
+    ("/rtsess01", "/rtsess01"),
+    ("/data1", "/data1"),
 )
 
 VERSION = click.version_option(version=__version__)
@@ -30,7 +30,7 @@ IMAGE_VERSION = click.option(
 IMAGE_USER = click.option(
     "--image_user",
     default="papaemmelab",
-    help="docker hub user/organization name",
+    help="docker hub {user}/{organization} name",
     show_default=True,
 )
 IMAGE_URL = click.option(
@@ -53,21 +53,21 @@ TMPVAR = click.option(
     "--tmpvar",
     show_default=True,
     help="environment variable used for workdir: --workDir ${tmpvar}",
-    default="$TMP_DIR",
+    default=os.getenv("REGISTER_APP_TMPVAR", "TMP_DIR"),
 )
 BINDIR = click.option(
     "--bindir",
     show_default=True,
     type=click.Path(resolve_path=True, dir_okay=True),
     help="path were executables will be linked to",
-    default=os.getenv("TOIL_REGISTER_BIN", _DEFAULT_BINDIR),
+    default=os.getenv("REGISTER_APP_BIN", _DEFAULT_BINDIR),
 )
 OPTDIR = click.option(
     "--optdir",
     show_default=True,
     type=click.Path(resolve_path=True, dir_okay=True),
     help="path were images will be versioned and cached",
-    default=os.getenv("TOIL_REGISTER_OPT", _DEFAULT_OPTDIR),
+    default=os.getenv("REGISTER_APP_OPT", _DEFAULT_OPTDIR),
 )
 PYTHON2 = click.option(
     "--python",

--- a/register_apps/options.py
+++ b/register_apps/options.py
@@ -48,7 +48,7 @@ VOLUMES = click.option(
     "--volumes",
     type=click.Tuple([click.Path(exists=True, resolve_path=True, dir_okay=True), str]),
     multiple=True,
-    default=get_default_volumes(),
+    default=get_default_volumes,
     show_default=False,
     help=f"volumes tuples to be passed to the container command. Use $REGISTER_APPS_VOLUMES. [default={get_default_volumes()}]",
 )

--- a/register_apps/options.py
+++ b/register_apps/options.py
@@ -55,8 +55,8 @@ VOLUMES = click.option(
 TMPVAR = click.option(
     "--tmpvar",
     show_default=True,
-    help="environment variable used for workdir: --workDir ${tmpvar}. Use $REGISTER_APPS_TMPVAR",
-    default=os.getenv("REGISTER_APPS_TMPVAR", "TMP_DIR"),
+    help="environment variable used for workdir: --workDir ${tmpvar}. Use $REGISTER_APPS_TMPVAR or $TMP_DIR/$TMPDIR/$TMP.",
+    default=os.getenv("REGISTER_APPS_TMPVAR") or os.getenv("TMP_DIR") or os.getenv("TMPDIR") or os.getenv("TMP") or "/tmp",
 )
 BINDIR = click.option(
     "--bindir",

--- a/register_apps/options.py
+++ b/register_apps/options.py
@@ -84,6 +84,12 @@ PYTHON3 = click.option(
     help="which python to be used for the virtual environment",
     default="python3",
 )
+VIRTUALENVWRAPPER = click.option(
+    "--virtualenvwrapper",
+    show_default=True,
+    help="path to virtualenvwrapper.sh",
+    default="virtualenvwrapper.sh",
+)
 DOCKER = click.option(
     "--docker",
     show_default=True,

--- a/register_apps/options.py
+++ b/register_apps/options.py
@@ -121,3 +121,10 @@ FORCE = click.option(
     required=False,
     help="Overwrite target executable and scripts (and images) if they already exist",
 )
+CONTAINER = click.option(
+    "--container",
+    show_default=True,
+    default="singularity",
+    type=click.Choice(["docker", "singularity"]),
+    help="container runtime to be used (docker or singularity)",
+)

--- a/register_apps/options.py
+++ b/register_apps/options.py
@@ -111,7 +111,7 @@ TARGET = click.option(
 COMMAND = click.option(
     "--command",
     show_default=True,
-    required=True,
+    default="",
     help="command that will be added at the end of the singularity exec instruction "
     "(e.g. bwa_mem.pl)",
 )
@@ -126,5 +126,18 @@ CONTAINER = click.option(
     show_default=True,
     default="singularity",
     type=click.Choice(["docker", "singularity"]),
-    help="container runtime to be used (docker or singularity)",
+    help="container runtime to be used: docker or singularity.",
+)
+ENVIRONMENT = click.option(
+    "--environment",
+    show_default=True,
+    default="production",
+    type=click.Choice(["production", "development", "testing", "staging"]),
+    help="Development Environment: production, development, testing, or staging.",
+)
+NO_HOME = click.option(
+    "--no-home",
+    is_flag=True,
+    required=False,
+    help="Use singularity --no-home option, to avoid mounting users home directory",
 )

--- a/setup.json
+++ b/setup.json
@@ -20,7 +20,7 @@
         "pytest-runner==2.11.1"
     ],
     "install_requires": [
-        "click==6.7",
+        "click>=7.0.0",
         "virtualenvwrapper==4.8.2"
     ],
     "extras_require": {

--- a/setup.json
+++ b/setup.json
@@ -11,9 +11,10 @@
     ],
     "entry_points": {
         "console_scripts": [
-            "register_toil=register_apps.cli:register_toil",
+            "register_docker=register_apps.cli:register_docker",
+            "register_python=register_apps.cli:register_python",
             "register_singularity=register_apps.cli:register_singularity",
-            "register_python=register_apps.cli:register_python"
+            "register_toil=register_apps.cli:register_toil"
         ]
     },
     "setup_requires": [

--- a/test-container.sh
+++ b/test-container.sh
@@ -12,7 +12,7 @@ if [ "$1" = "--skip-build" ]; then
     echo "skipping build..."
 else
     echo "building image, to skip run with --skip-build..."
-    docker build -q -t $TEST_IMAGE .
+    docker build -t $TEST_IMAGE .
 fi
 
 # see https://explainshell.com/explain?cmd=set+-euxo%20pipefail
@@ -24,7 +24,7 @@ find . -name '*.pyc' -exec rm {} +
 find . -name '__pycache__' -exec rm -rf {} +
 
 # run tox inside the container
-docker run --rm $TEST_IMAGE --version
+docker run --rm $TEST_IMAGE --help
 docker run -it --privileged --rm --entrypoint "" -v `pwd`:/test -w /test \
     $TEST_IMAGE bash -c "cp -r /test /register_apps && cd /register_apps && pip install tox && tox && cp .coverage /test"
 

--- a/test-container.sh
+++ b/test-container.sh
@@ -25,7 +25,7 @@ find . -name '__pycache__' -exec rm -rf {} +
 
 # run tox inside the container
 docker run --rm $TEST_IMAGE --help
-docker run -it --privileged --rm --entrypoint "" -v `pwd`:/test -w /test \
+docker run -it --privileged --rm --entrypoint "" -v `pwd`:/test -v /var/lib/docker:/var/lib/docker -w /test \
     $TEST_IMAGE bash -c "cp -r /test /register_apps && cd /register_apps && pip install tox && tox && cp .coverage /test"
 
 # move container coverage paths to local, see .coveragerc [paths] and this comment:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,7 +46,7 @@ def run_register_container(tmpdir, container_runtime):
         "--target",
         "bwa_mem.pl",
     ]
-    result = runner.invoke(container_cli, args)
+    result = runner.invoke(container_cli, args, catch_exceptions=False)
     if result.exit_code:
         print(vars(result))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ SKIP_DOCKER = pytest.mark.skipif(
     not utils.is_executable_available("docker"), reason="docker is not available."
 )
 
-def test_register_container(tmpdir, container_runtime):
+def run_register_container(tmpdir, container_runtime):
     runner = CliRunner()
     optdir = tmpdir.mkdir("opt")
     bindir = tmpdir.mkdir("bin")
@@ -25,31 +25,28 @@ def test_register_container(tmpdir, container_runtime):
     binexe = bindir.join("bwa_mem.pl")
     container_cli = cli.register_docker if container_runtime == "docker" else cli.register_singularity 
 
-    result = runner.invoke(
-        container_cli,
-        [
-            "--image_repository",
-            "docker-pcapcore",
-            "--image_version",
-            "v0.1.1",
-            "--image_user",
-            "leukgen",
-            "--volumes",
-            "/tmp",
-            "/carlos",
-            "--optdir",
-            optdir.strpath,
-            "--bindir",
-            bindir.strpath,
-            "--tmpvar",
-            "$TMP",
-            "--command",
-            "bwa_mem.pl",
-            "--target",
-            "bwa_mem.pl",
-        ],
-    )
-
+    args = [
+        "--image_repository",
+        "docker-pcapcore",
+        "--image_version",
+        "v0.1.1",
+        "--image_user",
+        "leukgen",
+        "--volumes",
+        "/tmp",
+        "/carlos",
+        "--optdir",
+        optdir.strpath,
+        "--bindir",
+        bindir.strpath,
+        "--tmpvar",
+        "$TMPDIR",
+        "--command",
+        "bwa_mem.pl",
+        "--target",
+        "bwa_mem.pl",
+    ]
+    result = runner.invoke(container_cli, args)
     if result.exit_code:
         print(vars(result))
 
@@ -68,13 +65,13 @@ def test_register_container(tmpdir, container_runtime):
 @SKIP_DOCKER
 def test_register_docker(tmpdir):
     """Sample test for register_docker command."""
-    test_register_container(tmpdir, container_runtime="docker")
+    run_register_container(tmpdir, container_runtime="docker")
 
 
 @SKIP_SINGULARITY
 def test_register_singularity(tmpdir):
     """Sample test for register_singularity command."""
-    test_register_container(tmpdir, container_runtime="singularity")
+    run_register_container(tmpdir, container_runtime="singularity")
 
 
 @SKIP_SINGULARITY

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,15 +80,15 @@ def test_register_toil(tmpdir):
     runner = CliRunner()
     optdir = tmpdir.mkdir("opt")
     bindir = tmpdir.mkdir("bin")
-    optexe = optdir.join("toil_disambiguate", "v0.1.2", "toil_disambiguate")
-    binexe = bindir.join("toil_disambiguate_v0.1.2")
+    optexe = optdir.join("toil_container", "v2.0.3", "toil_container")
+    binexe = bindir.join("toil_container_v2.0.3")
     result = runner.invoke(
         cli.register_toil,
         [
             "--pypi_name",
-            "toil_disambiguate",
+            "toil_container",
             "--pypi_version",
-            "v0.1.2",
+            "v2.0.3",
             "--image_user",
             "leukgen",
             "--volumes",
@@ -100,6 +100,8 @@ def test_register_toil(tmpdir):
             bindir.strpath,
             "--tmpvar",
             "$TMP",
+            "--python",
+            "python3",
         ],
     )
 
@@ -121,21 +123,21 @@ def test_register_python(tmpdir):
     runner = CliRunner()
     optdir = tmpdir.mkdir("opt")
     bindir = tmpdir.mkdir("bin")
-    optexe = optdir.join("toil_snapigv", "v0.1.1", "toil_snapigv")
-    binexe = bindir.join("toil_snapigv_v0.1.1")
+    optexe = optdir.join("toil_container", "v2.0.3", "toil_container")
+    binexe = bindir.join("toil_container_v2.0.3")
     result = runner.invoke(
         cli.register_python,
         [
             "--pypi_name",
-            "toil_snapigv",
+            "toil_container",
             "--pypi_version",
-            "v0.1.1",
+            "v2.0.3",
             "--optdir",
             optdir.strpath,
             "--bindir",
             bindir.strpath,
             "--python",
-            "python2",
+            "python3",
         ],
     )
 
@@ -154,15 +156,15 @@ def test_register_python_github(tmpdir):
     runner = CliRunner()
     optdir = tmpdir.mkdir("opt")
     bindir = tmpdir.mkdir("bin")
-    optexe = optdir.join("toil_snapigv", "v0.1.1", "toil_snapigv")
-    binexe = bindir.join("toil_snapigv_v0.1.1")
+    optexe = optdir.join("toil_container", "v2.0.3", "toil_container")
+    binexe = bindir.join("toil_container_v2.0.3")
     result = runner.invoke(
         cli.register_python,
         [
             "--pypi_name",
-            "toil_snapigv",
+            "toil_container",
             "--pypi_version",
-            "v0.1.1",
+            "v2.0.3",
             "--optdir",
             optdir.strpath,
             "--bindir",
@@ -170,7 +172,7 @@ def test_register_python_github(tmpdir):
             "--github_user",
             "papaemmelab",
             "--python",
-            "python2",
+            "python3",
         ],
     )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,15 +3,18 @@
 import subprocess
 
 
-def is_singularity_available():
+def is_executable_available(executable):
     """
-    Check if singularity is available to run in the current environment.
+    Check if an executable is available to run in the current environment.
+
+    Args:
+        executable (str): name of the executable to check.
 
     Returns:
-        bool: True if singularity is available.
+        bool: True if the executable is available.
     """
     try:
-        subprocess.check_output(["singularity", "--version"])
+        subprocess.check_output([executable, "--version"])
         return True
     except (subprocess.CalledProcessError, OSError):
         return False

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist = py36
 
-
 [testenv]
 usedevelop = True
 passenv = *


### PR DESCRIPTION
Add:
- `register_docker`: to create docker scripts as executables
- `--force`: to force overwriting existing targets
- ENV vars to configure the default values for `--bindir`, `--optdir`, `--tmpvar` and `--volumes`.

**Checklist:**
- [ ] 🐛 &nbsp; Bug fix
- [X] 🚀 &nbsp; New feature
- [ ] 🔧 &nbsp; Code refactor
- [ ] ⚠️ &nbsp; Breaking change that would cause existing functionality to change
- [ ] 📘 &nbsp; I have updated the documentation accordingly
- [X] ✅ &nbsp; I have added tests to cover my changes
